### PR TITLE
Add support for prefix subscriptions

### DIFF
--- a/composer/src/com/satori/composer/rtm/RtmChannelSubscriber.java
+++ b/composer/src/com/satori/composer/rtm/RtmChannelSubscriber.java
@@ -14,12 +14,14 @@ public abstract class RtmChannelSubscriber extends RtmChannel implements IRtmSub
   private final String channel;
   private final String filter;
   private final Map history;
+  private final boolean prefix;
   
   public RtmChannelSubscriber(Vertx vertx, RtmDriverConfig config, String name) {
     super(vertx, config, name);
     channel = config.channel;
     filter = config.filter;
     history = config.history;
+    prefix = config.prefix;
   }
   
   @Override
@@ -54,6 +56,9 @@ public abstract class RtmChannelSubscriber extends RtmChannel implements IRtmSub
   public String channel() {
     return channel;
   }
+  
+  @Override
+  public boolean prefix() { return prefix; }
   
   @Override
   public String filter() {

--- a/composer/src/com/satori/composer/rtm/RtmDriverConfig.java
+++ b/composer/src/com/satori/composer/rtm/RtmDriverConfig.java
@@ -14,6 +14,9 @@ public class RtmDriverConfig extends RtmBaseConfig {
   @JsonProperty("channel")
   public String channel = null;
   
+  @JsonProperty("prefix")
+  public Boolean prefix = null;
+  
   @JsonProperty("filter")
   public String filter = null;
   

--- a/composer/src/com/satori/composer/rtm/RtmDriverConfig.java
+++ b/composer/src/com/satori/composer/rtm/RtmDriverConfig.java
@@ -15,7 +15,7 @@ public class RtmDriverConfig extends RtmBaseConfig {
   public String channel = null;
   
   @JsonProperty("prefix")
-  public Boolean prefix = null;
+  public boolean prefix = false;
   
   @JsonProperty("filter")
   public String filter = null;

--- a/composer/src/com/satori/composer/rtm/core/IRtmChannelContext.java
+++ b/composer/src/com/satori/composer/rtm/core/IRtmChannelContext.java
@@ -6,6 +6,8 @@ public interface IRtmChannelContext extends IRtmContext {
   
   String channel();
   
+  boolean prefix();
+  
   String filter();
   
   Map history();

--- a/composer/src/com/satori/composer/rtm/core/RtmSubscribePdu.java
+++ b/composer/src/com/satori/composer/rtm/core/RtmSubscribePdu.java
@@ -10,6 +10,9 @@ public class RtmSubscribePdu extends RtmPdu<RtmSubscribePdu.Body> {
   public static class Body {
     @JsonProperty("channel")
     public String channel;
+  
+    @JsonProperty("prefix")
+    public boolean prefix = false;
     
     @JsonProperty("subscription_id")
     public String subscription;
@@ -22,40 +25,26 @@ public class RtmSubscribePdu extends RtmPdu<RtmSubscribePdu.Body> {
 
     @JsonProperty("history")
     public Map history;
-    
-    public Body(String channel, String filter, String next, Map history) {
+  
+    public Body(String channel, boolean prefix, String filter, String next, Map history) {
       if (filter != null && !filter.isEmpty()) {
         this.filter = filter;
         this.subscription = channel;
       } else {
         this.channel = channel;
       }
+      if(prefix) {
+        this.subscription = channel;
+      }
+      this.prefix = prefix;
       this.next = next;
       this.history = history;
     }
-    
-    public Body(String channel, String filter) {
-      this(channel, filter, null, null);
-    }
   }
   
-  public RtmSubscribePdu(String channel, String filter, String id, String next, Map history) {
+  public RtmSubscribePdu(String channel, boolean prefix, String filter, String id, String next, Map history) {
     this.action = "rtm/subscribe";
-    this.body = new Body(channel, filter, next, history);
+    this.body = new Body(channel, prefix, filter, next, history);
     this.id = id;
   }
-  
-  public RtmSubscribePdu(String channel, String filter, String id, String next) {
-    this(channel, filter, id, next, null);
-  }
-  
-  public RtmSubscribePdu(String channel, String filter, String id) {
-    this(channel, filter, id, null);
-  }
-  
-  public RtmSubscribePdu(String channel, String filter) {
-    this(channel, filter, null, null);
-  }
-  
-  
 }

--- a/composer/src/com/satori/composer/rtm/core/RtmSubscriber.java
+++ b/composer/src/com/satori/composer/rtm/core/RtmSubscriber.java
@@ -130,11 +130,11 @@ public class RtmSubscriber extends RtmPduInterceptor<IRtmSubscriberContext> {
       if (!id.equals(pdu.id)) {
         return false;
       }
-  
-      boolean hasPosition = (pdu.body != null && pdu.body.get("position") != null);
+      
       if (pdu.action.equals("rtm/subscribe/ok")) {
+        JsonNode positionNode = pdu.body != null ? pdu.body.get("position") : null;
         enterSubscribedState(
-          hasPosition ? pdu.body.get("position").asText() : null, unsubscribe
+          positionNode != null ? positionNode.asText() : null, unsubscribe
         );
         return true;
       } else if (pdu.action.equals("rtm/subscribe/error")) {

--- a/composer/src/com/satori/composer/rtm/core/RtmSubscriber.java
+++ b/composer/src/com/satori/composer/rtm/core/RtmSubscriber.java
@@ -118,7 +118,7 @@ public class RtmSubscriber extends RtmPduInterceptor<IRtmSubscriberContext> {
           }
         }
       };
-      RtmSubscribePdu pdu = new RtmSubscribePdu(channel(), filter(), id, null, history());
+      RtmSubscribePdu pdu = new RtmSubscribePdu(channel(), prefix(), filter(), id, null);
       master.send(pdu);
     } catch (Throwable cause) {
       fail(cause);
@@ -130,10 +130,11 @@ public class RtmSubscriber extends RtmPduInterceptor<IRtmSubscriberContext> {
       if (!id.equals(pdu.id)) {
         return false;
       }
-      
+  
+      boolean hasPosition = (pdu.body != null && pdu.body.get("position") != null);
       if (pdu.action.equals("rtm/subscribe/ok")) {
         enterSubscribedState(
-          pdu.body != null ? pdu.body.get("position").asText() : null, unsubscribe
+          hasPosition ? pdu.body.get("position").asText() : null, unsubscribe
         );
         return true;
       } else if (pdu.action.equals("rtm/subscribe/error")) {
@@ -356,6 +357,10 @@ public class RtmSubscriber extends RtmPduInterceptor<IRtmSubscriberContext> {
   
   String channel() {
     return ctx.channel();
+  }
+  
+  boolean prefix() {
+    return ctx.prefix();
   }
   
   String filter() {

--- a/composer/src/com/satori/composer/rtm/core/RtmSubscriber.java
+++ b/composer/src/com/satori/composer/rtm/core/RtmSubscriber.java
@@ -118,7 +118,7 @@ public class RtmSubscriber extends RtmPduInterceptor<IRtmSubscriberContext> {
           }
         }
       };
-      RtmSubscribePdu pdu = new RtmSubscribePdu(channel(), prefix(), filter(), id, null);
+      RtmSubscribePdu pdu = new RtmSubscribePdu(channel(), prefix(), filter(), id, null, history());
       master.send(pdu);
     } catch (Throwable cause) {
       fail(cause);


### PR DESCRIPTION
RtmSubscribePdu requires a new prefix field to indicate the channel is
a prefix and the subscription is for all channel starting with the
prefix.